### PR TITLE
Adding some defensive try/except blocks in case the SimpliSafe back-end blows up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.0.3
+
+- Added protection against incorrect data from SimpliSafe back-end
+
 ## 1.0.2
 - Return status of login corrected spelling of credentials
 

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='simplisafe-python',
-      version='1.0.2',
+      version='1.0.3',
       description='Python 3 support for SimpliSafe alarm',
       url='https://github.com/w1ll1am23/simplisafe-python',
       author='William Scanlon',

--- a/src/simplipy/system.py
+++ b/src/simplipy/system.py
@@ -11,7 +11,7 @@ class SimpliSafeSystem(object):
     Represents a SimpliSafe alarm system.
     """
 
-    def __init__(self, api_interface, location_id, state):
+    def __init__(self, api_interface, location_id, state=None):
         """
         Alarm object.
 
@@ -39,41 +39,62 @@ class SimpliSafeSystem(object):
         Return the current temperature of the system.
         Will return null if API doesn't return an int.
         """
-        api_temp = self.sensors.get("freeze").get("temp")
         try:
+            api_temp = self.sensors.get("freeze").get("temp")
             return int(api_temp)
-        except ValueError:
+        except:
+            _LOGGER.error("Could not get current temperature")
             return None
 
     def carbon_monoxide(self):
         """
         Current state of CO sensor.
         """
-        return self.sensors.get("recent_co").get("text")
+        try:
+            return self.sensors.get("recent_co").get("text")
+        except:
+            _LOGGER.error("Could not get carbon monoxide detector state")
+            return None
 
     def flood(self):
         """
         Current state of flood sensor.
         """
-        return self.sensors.get("recent_flood").get("text")
+        try:
+            return self.sensors.get("recent_flood").get("text")
+        except:
+            _LOGGER.error("Could not get flood detector state")
+            return None
 
     def fire(self):
         """
         Current state of fire detector.
         """
-        return self.sensors.get("recent_fire").get("text")
+        try:
+            return self.sensors.get("recent_fire").get("text")
+        except:
+            _LOGGER.error("Could not get smoke detector state")
+            return None
 
     def alarm(self):
         """
         Current state of recent alarm.
         """
-        return self.sensors.get("recent_alarm").get("text")
+        try:
+            return self.sensors.get("recent_alarm").get("text")
+        except:
+            _LOGGER.error("Could not get last alarm state")
+            return None
 
     def last_event(self):
         """
         Return the last event sent by the system.
         """
-        return self.events.get("events")[0].get("event_desc")
+        try:
+            return self.events.get("events")[0].get("event_desc")
+        except:
+            _LOGGER.error("Could not get last event")
+            return None
 
     def update(self, retry=True):
         """


### PR DESCRIPTION
Hi there – there appears to be an issue with SimpliSafe wherein everyone's (or many people's) event logs are empty. This causes your library to throw an unhandled exception.

Since their "public API" isn't a real thing, this PR adds some very generic, very defensive `try/except` blocks that should catch this (and similar issues, should they ever occur).